### PR TITLE
remove unwanted ^M in curl output

### DIFF
--- a/ob-http.el
+++ b/ob-http.el
@@ -97,7 +97,7 @@
          (max-time (cdr (assoc :max-time params)))
          (select (cdr (assoc :select params)))
          (body (ob-http/request-body req))
-         (cmd (s-format "curl -is ${proxy} ${method} ${headers} ${cookie-jar} ${cookie} ${body} \"${url}\" --max-time ${max-time}" 'aget
+         (cmd (s-format "curl -is ${proxy} ${method} ${headers} ${cookie-jar} ${cookie} ${body} \"${url}\" --max-time ${max-time} | tr -d '\r'" 'aget
                         `(("proxy" . ,(if proxy (format "-x %s" proxy) ""))
                           ("method" . ,(let ((method (ob-http/request-method req)))
                                          (if (string= "HEAD" method) "-I" (format "-X %s" method))))


### PR DESCRIPTION
curl outputs \r in the header-section wich is mildly annoying.