### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,7 +40,7 @@ To use =ob-http= in an =org-babel= source block, the http language must be enabl
 
 ** examples
    
-**** set arbitary header
+**** set arbitrary header
 
 : #+BEGIN_SRC http :pretty
 : GET http://httpbin.org/user-agent


### PR DESCRIPTION
@zweifisch, I've corrected a typographical error in the documentation of the [ob-http](https://github.com/zweifisch/ob-http) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.