### PR TITLE
Small fixes

### DIFF
--- a/ob-http.el
+++ b/ob-http.el
@@ -29,6 +29,7 @@
 (require 'org)
 (require 'ob)
 (require 's)
+(require 'subr-x)
 (require 'json)
 (require 'ob-http-mode)
 (require 'cl-lib)

--- a/ob-http.el
+++ b/ob-http.el
@@ -136,7 +136,7 @@
 (defun ob-http-pretty (body content-type)
   (if (string= "" body)
       body
-    (case (ob-http-parse-content-type content-type)
+    (cl-case (ob-http-parse-content-type content-type)
       (json (ob-http-pretty-json body))
       (xml (ob-http-pretty-xml body))
       (html (ob-http-pretty-html body))


### PR DESCRIPTION
Fixes zweifisch/ob-http#19

- Use `cl-case` instead of just `case`
- Require `subr-x` for `string-join`