### PR TITLE
Add :resolve property

### DIFF
--- a/README.org
+++ b/README.org
@@ -38,7 +38,8 @@ To use =ob-http= in an =org-babel= source block, the http language must be enabl
 | =:pretty=     | N/A            | =:pretty= use =Content-Type=, to overwrite =:pretty json=                               |
 | =:select=     | N/A            | =:select path= path will be passed to [[https://stedolan.github.io/jq/][jq]] for json or [[https://github.com/EricChiang/pup][pup]] for html or [[http://xmlstar.sourceforge.net/][xmlstarlet]] for xml |
 | =:get-header= | N/A            | =:get-header X-Subject-Token=                                                           |
-| =:curl=       | N/A            | =:curl --insecure --compressed= additional arguments for curl
+| =:curl=       | N/A            | =:curl --insecure --compressed= additional arguments for curl                           |
+| =:resolve=    | =--resolve=    | =:resolve example.com:80:127.0.0.1,example.com:443:127.0.0.1=                           |
 
 ** examples
    

--- a/ob-http.el
+++ b/ob-http.el
@@ -47,6 +47,7 @@
     (password . :any)
     (follow-redirect . :any)
     (path-prefix . :any)
+    (resolve . :any)
     (max-time . :any))
   "http header arguments")
 
@@ -217,6 +218,7 @@
          (cookie (cdr (assoc :cookie params)))
          (curl (cdr (assoc :curl params)))
          (select (cdr (assoc :select params)))
+         (resolve (cdr (assoc :resolve params)))
          (request-body (ob-http-request-body request))
          (error-output (org-babel-temp-file "curl-error"))
          (args (append ob-http:curl-custom-arguments (list "-i"
@@ -232,6 +234,7 @@
                          `("-d" ,(format "@%s" tmp))))
                      (when cookie-jar `("--cookie-jar" ,cookie-jar))
                      (when cookie `("--cookie" ,cookie))
+                     (when resolve (mapcar (lambda (x) `("--resolve" ,x)) (split-string resolve ",")))
                      (when curl (split-string-and-unquote curl))
                      "--max-time"
                      (int-to-string (or (cdr (assoc :max-time params))


### PR DESCRIPTION
This property is useful when trying to test a site on a different IP without editing hosts file (or DNS for that matter).