### PR TITLE
Parse HTTP2 response headers as headers

### DIFF
--- a/ob-http.el
+++ b/ob-http.el
@@ -93,8 +93,8 @@
 
 (defun ob-http-split-header-body (input)
   (let ((splited (s-split-up-to "\\(\r\n\\|[\n\r]\\)[ \t]*\\1" input 1)))
-    (if (and (string-match "^HTTP/1.[0-1] \\(30\\|100\\)" (car splited))
-             (string-match "^HTTP/1.[0-1]" (cadr splited)))
+    (if (and (string-match "^HTTP/\\(1.[0-1]\\|2\\) \\(30\\|100\\)" (car splited))
+             (string-match "^HTTP/\\(1.[0-1]\\|2\\)" (cadr splited)))
         (ob-http-split-header-body (cadr splited))
       splited)))
 


### PR DESCRIPTION
* ob-http.el (ob-http-split-header-body): Extend regex to recognize
  HTTP/2 response headers.