### PR TITLE
Substitute variables on export

### DIFF
--- a/ob-http.el
+++ b/ob-http.el
@@ -263,6 +263,22 @@
                    (s-join "\n" (s-lines (buffer-string)))))
           "")))))
 
+(defun ob-http-export-expand-variables (&optional backend)
+  "Scan current buffer for all HTTP source code blocks and expand variables.
+
+Add this function to `org-export-before-processing-hook' to
+enable variable expansion before source block is exported."
+  (let ((case-fold-search t) elt replacement)
+    (save-excursion
+      (goto-char (point-min))
+      (while (search-forward-regexp "^[ \t]+#\\+begin_src[ \t]+http" nil 'noerror)
+        (setq elt (org-element-at-point))
+        (when (eq 'src-block (car elt))
+          (setq replacement (org-babel-expand-src-block))
+          (goto-char (org-element-property :begin elt))
+          (delete-region (org-element-property :begin elt) (org-element-property :end elt))
+          (insert (org-element-interpret-data (org-element-put-property elt :value replacement))))))))
+
 (eval-after-load "org"
   '(add-to-list 'org-src-lang-modes '("http" . "ob-http")))
 

--- a/ob-http.el
+++ b/ob-http.el
@@ -271,7 +271,7 @@ enable variable expansion before source block is exported."
   (let ((case-fold-search t) elt replacement)
     (save-excursion
       (goto-char (point-min))
-      (while (search-forward-regexp "^[ \t]+#\\+begin_src[ \t]+http" nil 'noerror)
+      (while (search-forward-regexp "^[ \t]*#\\+begin_src[ \t]+http" nil 'noerror)
         (setq elt (org-element-at-point))
         (when (eq 'src-block (car elt))
           (setq replacement (org-babel-expand-src-block))


### PR DESCRIPTION
* ob-http.el (ob-http-export-expand-variables): New function handling
  variable substitution.

To use this functionality, the function has to be added to Org export
hook (org-export-before-processing-hook) before the source blocks have
been executed.

It might be possible to hook it up somewhere in `ob-http' internals, but
this seems like a cleaner solution. And it should not break anything by
itself (until it gets added to the hook, that is).

References issue #25.