### PR TITLE
Quote all arguments in command history buffer

### DIFF
--- a/ob-http.el
+++ b/ob-http.el
@@ -244,8 +244,9 @@
                      (ob-http-construct-url (ob-http-request-url request) params)))))
     (with-current-buffer (get-buffer-create "*curl commands history*")
       (goto-char (point-max))
-      (let ((cmd-line (concat "curl " (string-join (ob-http-flatten args) " ") "\n")))
-        (insert (replace-regexp-in-string "--noproxy \\*"  "--noproxy '*'" cmd-line))))
+      (insert "curl "
+              (string-join (mapcar 'shell-quote-argument (ob-http-flatten args)) " ")
+              "\n"))
     (with-current-buffer (get-buffer-create "*curl output*")
       (erase-buffer)
       (if (= 0 (apply 'call-process "curl" nil `(t ,error-output) nil (ob-http-flatten args)))


### PR DESCRIPTION
With this change, you can copy a command from the history buffer and
paste it in the terminal without having to quote any arguments
manually.  For example, before this change, a "Content-Type" header
would appear like this:

    -H Content-Type: application/json

and after the change like this:

    -H Content-Type\:\ application/json