### PR TITLE
Scheme not schema

### DIFF
--- a/README.org
+++ b/README.org
@@ -151,7 +151,7 @@ supported headers:
 - proxy
 - noproxy
 - cookie
-- schema
+- scheme
 - host
 - port
 - user

--- a/ob-http.el
+++ b/ob-http.el
@@ -39,7 +39,7 @@
     (noproxy . :any)
     (curl . :any)
     (cookie . :any)
-    (schema . :any)
+    (scheme . :any)
     (host . :any)
     (port . :any)
     (user . :any)
@@ -190,7 +190,7 @@
 (defun ob-http-construct-url (path params)
   (if (s-starts-with? "/" path)
       (s-concat
-       (format "%s://" (or (assoc-default :schema params) "http"))
+       (format "%s://" (or (assoc-default :scheme params) "http"))
        (assoc-default :host params)
        (when (assoc :port params)
              (format ":%s" (assoc-default :port params)))

--- a/tests.el
+++ b/tests.el
@@ -17,6 +17,6 @@
 
   (let ((params '((:host . "localhost")
                   (:port . 8080)
-                  (:schema . "https"))))
+                  (:scheme . "https"))))
     (should (equal (ob-http-construct-url "/" params)
                    "https://localhost:8080/"))))


### PR DESCRIPTION
Correct all occurrances of "schema" to "scheme" in accordance with [RFC 3986](https://tools.ietf.org/html/rfc3986)'s definition of the term.