### PR TITLE
URL encode request URIs by default

### DIFF
--- a/ob-http.el
+++ b/ob-http.el
@@ -79,7 +79,7 @@
          (method-url (split-string (car headers) " ")))
     (make-ob-http-request
      :method (car method-url)
-     :url (cadr method-url)
+     :url (url-encode-url (cadr method-url))
      :headers (if (cadr headers) (s-lines (cadr headers)))
      :body (cadr headers-body))))
 


### PR DESCRIPTION
If there are any non-ASCII characters in the request URI, `curl` will send
those through in raw UTF-8 form by default. That is almost never what
you'd want, since all server frameworks will expect non-ASCII characters
to be percent-encoded.

The built-in `url-encode-url` function does exactly that, so we pass our
request URI through it.

Please let me know if this should be a switch instead; I couldn't think of a case where you _wouldn't_ want this.