### PR TITLE
Fix org-src-lang-modes

### DIFF
--- a/README.org
+++ b/README.org
@@ -41,6 +41,7 @@ To use =ob-http= in an =org-babel= source block, the http language must be enabl
 | =:get-header= | N/A            | =:get-header X-Subject-Token=                                                           |
 | =:curl=       | N/A            | =:curl --insecure --compressed= additional arguments for curl                           |
 | =:resolve=    | =--resolve=    | =:resolve example.com:80:127.0.0.1,example.com:443:127.0.0.1=                           |
+| =:data-binary= | =--data-binary= | Use =--data-binary= instead of =--data= in the curl command                               |
 
 ** examples
    
@@ -156,6 +157,7 @@ supported headers:
 - port
 - user
 - max-time
+- data-binary
 
 : * api test
 : :PROPERTIES:
@@ -196,3 +198,36 @@ supported headers:
 : #+RESULTS:
 : [[file:zweifisch.jpeg]]
 
+
+    other data payloads
+
+: #+BEGIN_SRC http :data-binary
+: POST http://httpbin.org/post
+: Content-Type: application/octet-stream
+:
+: lots
+: of
+: line breaks
+: and insignificant=punctuation
+: #+END_SRC
+:
+: #+RESULTS:
+: #+begin_example
+: {
+:   "args": {},
+:   "data": "lots\nof\nline breaks\nand insignificant=punctuation",
+:   "files": {},
+:   "form": {},
+:   "headers": {
+:     "Accept": "*/*",
+:     "Content-Length": "48",
+:     "Content-Type": "application/octet-stream",
+:     "Host": "httpbin.org",
+:     "User-Agent": "curl/7.87.0",
+:     "X-Amzn-Trace-Id": "Root=1-6449b5bf-1e5eac452e4393943dce4a61"
+:   },
+:   "json": null,
+:   "origin": "44.237.72.92",
+:   "url": "http://httpbin.org/post"
+: }
+: #+end_example

--- a/README.org
+++ b/README.org
@@ -16,7 +16,6 @@ http request in org-mode babel, requires curl
 : : }
 
 The resulting plain curl calls can be seen at =*curl commands history*= buffer.
-Or use the =:print-curl= option to only output the body as string instead.
 
 ** setup
 

--- a/README.org
+++ b/README.org
@@ -15,6 +15,9 @@ http request in org-mode babel, requires curl
 : :   "Emacs Lisp": 8170
 : : }
 
+The resulting plain curl calls can be seen at =*curl commands history*= buffer.
+Or use the =:print-curl= option to only output the body as string instead.
+
 ** setup
 
 To use =ob-http= in an =org-babel= source block, the http language must be enabled in the custom =org-babel-load-languages= alist. Alternatively, running the following snippet during initialization will enable the mode.
@@ -35,13 +38,14 @@ To use =ob-http= in an =org-babel= source block, the http language must be enabl
 | =:cookie-jar= | =--cookie-jar= | =:cookie-jar username=                                                                  |
 | =:cookie=     | =--cookie=     | =:cookie username=                                                                      |
 | =:max-time=   | =--max-time=   | default is =10=                                                                         |
-| =:user=       | =--user=       | =:user admin:passwd=
+| =:user=       | =--user=       | =:user admin:passwd=                                                                    |
 | =:pretty=     | N/A            | =:pretty= use =Content-Type=, to overwrite =:pretty json=                               |
 | =:select=     | N/A            | =:select path= path will be passed to [[https://stedolan.github.io/jq/][jq]] for json or [[https://github.com/EricChiang/pup][pup]] for html or [[http://xmlstar.sourceforge.net/][xmlstarlet]] for xml |
 | =:get-header= | N/A            | =:get-header X-Subject-Token=                                                           |
 | =:curl=       | N/A            | =:curl --insecure --compressed= additional arguments for curl                           |
 | =:resolve=    | =--resolve=    | =:resolve example.com:80:127.0.0.1,example.com:443:127.0.0.1=                           |
 | =:data-binary= | =--data-binary= | Use =--data-binary= instead of =--data= in the curl command                               |
+| =:print-curl= | N/A            | Outputs the generated curl call as a string instead of actually calling curl.           |
 
 ** examples
    
@@ -190,6 +194,9 @@ supported headers:
 : #+end_example
 
 **** files
+:PROPERTIES:
+:ID:       E04A1F39-5B5E-4EDE-BF71-8FD3E8A7218E
+:END:
 
 : #+BEGIN_SRC http :file zweifisch.jpeg
 : GET https://avatars.githubusercontent.com/u/447862?v=3

--- a/ob-http.el
+++ b/ob-http.el
@@ -48,7 +48,8 @@
     (follow-redirect . :any)
     (path-prefix . :any)
     (resolve . :any)
-    (max-time . :any))
+    (max-time . :any)
+    (data-binary . :any))
   "http header arguments")
 
 (defgroup ob-http nil
@@ -219,6 +220,7 @@
          (resolve (cdr (assoc :resolve params)))
          (request-body (ob-http-request-body request))
          (error-output (org-babel-temp-file "curl-error"))
+         (binary (assoc :data-binary params))
          (args (append ob-http:curl-custom-arguments (list "-i"
                      (when (and proxy (not noproxy)) `("-x" ,proxy))
                      (when noproxy '("--noproxy" "*"))
@@ -230,9 +232,10 @@
                      (when (assoc :user params) `("--user" ,(cdr (assoc :user params))))
                      (mapcar (lambda (x) `("-H" ,x)) (ob-http-request-headers request))
                      (when (s-present? request-body)
-                       (let ((tmp (org-babel-temp-file "http-")))
+                       (let ((tmp (org-babel-temp-file "http-"))
+                             (data-opt (if binary "--data-binary" "--data")))
                          (with-temp-file tmp (insert request-body))
-                         `("-d" ,(format "@%s" tmp))))
+                         (list data-opt (format "@%s" tmp))))
                      (when cookie-jar `("--cookie-jar" ,cookie-jar))
                      (when cookie `("--cookie" ,cookie))
                      (when resolve (mapcar (lambda (x) `("--resolve" ,x)) (split-string resolve ",")))

--- a/ob-http.el
+++ b/ob-http.el
@@ -206,6 +206,7 @@
 
 (defun org-babel-execute:http (body params)
   (let* ((request (ob-http-parse-request (org-babel-expand-body:http body params)))
+	 (print-curl (assoc :print-curl params))
          (proxy (cdr (assoc :proxy params)))
          (noproxy (assoc :noproxy params))
          (follow-redirect (and (assoc :follow-redirect params) (not (string= "no" (cdr (assoc :follow-redirect params))))))
@@ -245,6 +246,11 @@
                                         ob-http:max-time))
                      "--globoff"
                      (ob-http-construct-url (ob-http-request-url request) params)))))
+    
+    (if print-curl (concat "curl "
+              (string-join (mapcar 'shell-quote-argument (ob-http-flatten args)) " ")
+              "\n")
+      
     (with-current-buffer (get-buffer-create "*curl commands history*")
       (goto-char (point-max))
       (insert "curl "
@@ -265,7 +271,7 @@
           (princ (with-temp-buffer
                    (insert-file-contents-literally error-output)
                    (s-join "\n" (s-lines (buffer-string)))))
-          "")))))
+          ""))))))
 
 (defun ob-http-export-expand-variables (&optional backend)
   "Scan current buffer for all HTTP source code blocks and expand variables.

--- a/ob-http.el
+++ b/ob-http.el
@@ -252,7 +252,7 @@
               "\n"))
     (with-current-buffer (get-buffer-create "*curl output*")
       (erase-buffer)
-      (if (= 0 (apply 'call-process "curl" nil `(t ,error-output) nil (ob-http-flatten args)))
+      (if (= 0 (apply 'process-file "curl" nil `(t ,error-output) nil (ob-http-flatten args)))
           (let ((response (ob-http-parse-response (buffer-string))))
             (when prettify (ob-http-pretty-response response (cdr pretty)))
             (when ob-http:remove-cr (ob-http-remove-carriage-return response))

--- a/ob-http.el
+++ b/ob-http.el
@@ -290,7 +290,7 @@ enable variable expansion before source block is exported."
           (insert (org-element-interpret-data (org-element-put-property elt :value replacement))))))))
 
 (eval-after-load "org"
-  '(add-to-list 'org-src-lang-modes '("http" . "ob-http")))
+  '(add-to-list 'org-src-lang-modes '("http" . ob-http)))
 
 (provide 'ob-http)
 ;;; ob-http.el ends here

--- a/ob-http.el
+++ b/ob-http.el
@@ -80,7 +80,7 @@
          (method-url (split-string (car headers) " ")))
     (make-ob-http-request
      :method (car method-url)
-     :url (cadr method-url)
+     :url (url-encode-url (cadr method-url))
      :headers (if (cadr headers) (s-lines (cadr headers)))
      :body (cadr headers-body))))
 

--- a/ob-http.el
+++ b/ob-http.el
@@ -94,7 +94,7 @@
 
 (defun ob-http-split-header-body (input)
   (let ((splited (s-split-up-to "\\(\r\n\\|[\n\r]\\)[ \t]*\\1" input 1)))
-    (if (and (string-match "^HTTP/\\(1.[0-1]\\|2\\) \\(30\\|100\\)" (car splited))
+    (if (and (string-match "^HTTP/\\(1.[0-1]\\|2\\) \\(30\\|100\\|200\\)" (car splited))
              (string-match "^HTTP/\\(1.[0-1]\\|2\\)" (cadr splited)))
         (ob-http-split-header-body (cadr splited))
       splited)))


### PR DESCRIPTION
Hey thanks for this mode: it is very useful at work!!

The   org-src-lang-modes list contains cons-cell with symbols, not strings: `(("amm" . scala) ("arduino" . arduino) ("translate" . text) ("redis" . redis) ("php" . php) ("C" . c) ("C++" . c++) ("asymptote" . asy) ("bash" . sh) ...)`

It was causing `Wrong type argument: symbolp, "ob-http"` on tangling snippets.