### PR TITLE
Allow breaking long lines for readbility.

### DIFF
--- a/README.org
+++ b/README.org
@@ -199,16 +199,16 @@ supported headers:
 **** break long lines
 
 Especially when working with a lot of query parameters it might be useful to split lines.
-Therefore, lines that start with ~\~ (or whatever matches ~ob-http:join-line-marker~)
+Therefore, lines that start with one or more spaces or tabs (or whatever matches ~ob-http:join-line-marker~)
 will be merged into the previous line before processing.
 
 So the following two blocks are equivalent:
 
 : #+BEGIN_SRC http
 : GET https://api.github.com/repos/zweifisch/ob-http/pulls
-: \?state=open
-: \&sort=created-asc
-: \&no-assignee
+:  ?state=open
+:  &sort=created-asc
+:  &no-assignee
 : #+end_src
 
 : #+BEGIN_SRC http

--- a/README.org
+++ b/README.org
@@ -196,3 +196,21 @@ supported headers:
 : #+RESULTS:
 : [[file:zweifisch.jpeg]]
 
+**** break long lines
+
+Especially when working with a lot of query parameters it might be useful to split lines.
+Therefore, lines that start with ~\~ (or whatever matches ~ob-http:join-line-marker~)
+will be merged into the previous line before processing.
+
+So the following two blocks are equivalent:
+
+: #+BEGIN_SRC http
+: GET https://api.github.com/repos/zweifisch/ob-http/pulls
+: \?state=open
+: \&sort=created-asc
+: \&no-assignee
+: #+end_src
+
+: #+BEGIN_SRC http
+: GET https://api.github.com/repos/zweifisch/ob-http/pulls?state=open&sort=created-asc&no-assignee
+: #+end_src

--- a/ob-http.el
+++ b/ob-http.el
@@ -74,7 +74,8 @@
 (cl-defstruct ob-http-response headers body headers-map)
 
 (defun ob-http-parse-request (input)
-  (let* ((headers-body (ob-http-split-header-body input))
+  (let* ((input-with-marked-lines-merged (merge-marked-lines-into-previous-line input))
+         (headers-body (ob-http-split-header-body input-with-marked-lines-merged))
          (headers (s-split-up-to "\\(\r\n\\|[\n\r]\\)" (car headers-body) 1))
          (method-url (split-string (car headers) " ")))
     (make-ob-http-request
@@ -90,6 +91,10 @@
      :headers (car headers-body)
      :body (cadr headers-body)
      :headers-map headers-map)))
+
+;; todo allow mark to be customized
+(defun merge-marked-lines-into-previous-line (input)
+  (replace-regexp-in-string "\\(\r\n\\|[\n\r]\\)\\\\" "" input))
 
 (defun ob-http-split-header-body (input)
   (let ((splited (s-split-up-to "\\(\r\n\\|[\n\r]\\)[ \t]*\\1" input 1)))

--- a/ob-http.el
+++ b/ob-http.el
@@ -70,6 +70,11 @@
   :group 'ob-http
   :type '(repeat (string :format "%v")))
 
+(defcustom ob-http:join-line-marker "\\\\"
+  "Regexp that will cause the line following it being merged into the previous line"
+  :group 'ob-http
+  :type 'regexp)
+
 (cl-defstruct ob-http-request method url headers body)
 (cl-defstruct ob-http-response headers body headers-map)
 
@@ -92,9 +97,10 @@
      :body (cadr headers-body)
      :headers-map headers-map)))
 
-;; todo allow mark to be customized
 (defun merge-marked-lines-into-previous-line (input)
-  (replace-regexp-in-string "\\(\r\n\\|[\n\r]\\)\\\\" "" input))
+  "Merges the lines that's start match ob-http:join-line-marker into the line before."
+  (let ((undesired-linebreak-regexp (concat "\\(\r\n\\|[\n\r]\\)" ob-http:join-line-marker)))
+    (replace-regexp-in-string undesired-linebreak-regexp "" input)))
 
 (defun ob-http-split-header-body (input)
   (let ((splited (s-split-up-to "\\(\r\n\\|[\n\r]\\)[ \t]*\\1" input 1)))

--- a/ob-http.el
+++ b/ob-http.el
@@ -70,7 +70,7 @@
   :group 'ob-http
   :type '(repeat (string :format "%v")))
 
-(defcustom ob-http:join-line-marker "\\\\"
+(defcustom ob-http:join-line-marker "[ \t]+"
   "Regexp that will cause the line following it being merged into the previous line"
   :group 'ob-http
   :type 'regexp)


### PR DESCRIPTION

Especially when working with a lot of query parameters it might be useful to split lines.
Therefore, lines that start with `\` (or whatever matches `ob-http:join-line-marker`)
will be merged into the previous line before processing.

So the following lines would be equivalent:

```org-mode
#+BEGIN_SRC http
GET https://api.github.com/repos/zweifisch/ob-http/pulls
\?state=open
\&sort=created-asc
\&no-assignee
#+end_src
```

```org-mode
#+BEGIN_SRC http
GET https://api.github.com/repos/zweifisch/ob-http/pulls?state=open&sort=created-asc&no-assignee
#+end_src
```