### PR TITLE
Provide option to use --data-binary instead of -d/--data

### DIFF
--- a/README.org
+++ b/README.org
@@ -41,6 +41,7 @@ To use =ob-http= in an =org-babel= source block, the http language must be enabl
 | =:get-header= | N/A            | =:get-header X-Subject-Token=                                                           |
 | =:curl=       | N/A            | =:curl --insecure --compressed= additional arguments for curl                           |
 | =:resolve=    | =--resolve=    | =:resolve example.com:80:127.0.0.1,example.com:443:127.0.0.1=                           |
+| =:data-binary= | =--data-binary= | Use =--data-binary= instead of =--data= in the curl command                               |
 
 ** examples
    
@@ -156,6 +157,7 @@ supported headers:
 - port
 - user
 - max-time
+- data-binary
 
 : * api test
 : :PROPERTIES:
@@ -196,3 +198,36 @@ supported headers:
 : #+RESULTS:
 : [[file:zweifisch.jpeg]]
 
+
+    other data payloads
+
+: #+BEGIN_SRC http :data-binary
+: POST http://httpbin.org/post
+: Content-Type: application/octet-stream
+:
+: lots
+: of
+: line breaks
+: and insignificant=punctuation
+: #+END_SRC
+:
+: #+RESULTS:
+: #+begin_example
+: {
+:   "args": {},
+:   "data": "lots\nof\nline breaks\nand insignificant=punctuation",
+:   "files": {},
+:   "form": {},
+:   "headers": {
+:     "Accept": "*/*",
+:     "Content-Length": "48",
+:     "Content-Type": "application/octet-stream",
+:     "Host": "httpbin.org",
+:     "User-Agent": "curl/7.87.0",
+:     "X-Amzn-Trace-Id": "Root=1-6449b5bf-1e5eac452e4393943dce4a61"
+:   },
+:   "json": null,
+:   "origin": "44.237.72.92",
+:   "url": "http://httpbin.org/post"
+: }
+: #+end_example

--- a/ob-http.el
+++ b/ob-http.el
@@ -48,7 +48,8 @@
     (follow-redirect . :any)
     (path-prefix . :any)
     (resolve . :any)
-    (max-time . :any))
+    (max-time . :any)
+    (data-binary . :any))
   "http header arguments")
 
 (defgroup ob-http nil
@@ -219,6 +220,7 @@
          (resolve (cdr (assoc :resolve params)))
          (request-body (ob-http-request-body request))
          (error-output (org-babel-temp-file "curl-error"))
+         (binary (assoc :data-binary params))
          (args (append ob-http:curl-custom-arguments (list "-i"
                      (when (and proxy (not noproxy)) `("-x" ,proxy))
                      (when noproxy '("--noproxy" "*"))
@@ -230,9 +232,10 @@
                      (when (assoc :user params) `("--user" ,(cdr (assoc :user params))))
                      (mapcar (lambda (x) `("-H" ,x)) (ob-http-request-headers request))
                      (when (s-present? request-body)
-                       (let ((tmp (org-babel-temp-file "http-")))
+                       (let ((tmp (org-babel-temp-file "http-"))
+                             (data-opt (if binary "--data-binary" "--data")))
                          (with-temp-file tmp (insert request-body))
-                         `("-d" ,(format "@%s" tmp))))
+                         (list data-opt (format "@%s" tmp))))
                      (when cookie-jar `("--cookie-jar" ,cookie-jar))
                      (when cookie `("--cookie" ,cookie))
                      (when resolve (mapcar (lambda (x) `("--resolve" ,x)) (split-string resolve ",")))


### PR DESCRIPTION
`--data` assumes form encoded data, and does some processing like removing line-breaks. For other kinds of payload `curl` recommends you set `Content-Type` and use `--data-binary`, which is now possible with ob-http.